### PR TITLE
chore: replace vue-template-compiler with Vue 3 SFC compiler

### DIFF
--- a/build/vue-loader.conf.js
+++ b/build/vue-loader.conf.js
@@ -7,6 +7,10 @@ const sourceMapEnabled = isProduction
   : config.dev.cssSourceMap
 
 module.exports = {
+  // Options for the Vue 3 SFC compiler
+  compilerOptions: {
+    whitespace: 'condense'
+  },
   loaders: utils.cssLoaders({
     sourceMap: sourceMapEnabled,
     extract: isProduction

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "@babel/preset-env": "^7.24.5",
         "@babel/runtime": "^7.24.5",
         "@cyclonedx/cyclonedx-npm": "^4.0.0",
+        "@vue/compiler-sfc": "^3.5.17",
         "autoprefixer": "^10.4.21",
         "babel-eslint": "^10.1.0",
         "babel-helper-vue-jsx-merge-props": "^2.0.3",
@@ -72,7 +73,6 @@
         "vue-eslint-parser": "^10.1.3",
         "vue-loader": "^17.4.2",
         "vue-style-loader": "^4.1.3",
-        "vue-template-compiler": "^2.7.16",
         "webpack": "^5.99.9",
         "webpack-bundle-analyzer": "^4.10.2",
         "webpack-cli": "^6.0.1",
@@ -8709,13 +8709,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/de-indent": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
-      "integrity": "sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/debounce": {
       "version": "1.2.1",
@@ -21218,17 +21211,6 @@
       },
       "engines": {
         "node": ">=4.0.0"
-      }
-    },
-    "node_modules/vue-template-compiler": {
-      "version": "2.7.16",
-      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.16.tgz",
-      "integrity": "sha512-AYbUWAJHLGGQM7+cNTELw+KsOG9nl2CnSv467WobS5Cv9uk3wFcnr1Etsz2sEIHEZvw1U+o9mRlEO6QbZvUPGQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "de-indent": "^1.0.2",
-        "he": "^1.2.0"
       }
     },
     "node_modules/vuex": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "vue-eslint-parser": "^10.1.3",
     "vue-loader": "^17.4.2",
     "vue-style-loader": "^4.1.3",
-    "vue-template-compiler": "^2.7.16",
+    "@vue/compiler-sfc": "^3.5.17",
     "webpack": "^5.99.9",
     "webpack-bundle-analyzer": "^4.10.2",
     "webpack-cli": "^6.0.1",


### PR DESCRIPTION
## Summary
- remove legacy `vue-template-compiler`
- add `@vue/compiler-sfc` for Vue 3 single-file components
- enable Vue 3 compiler options in webpack configuration

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3e7bb3e4883278cabf8cef660026d